### PR TITLE
Prevent negative raw xCell2 enrichment scores caused by ties

### DIFF
--- a/R/xCell2Analysis.R
+++ b/R/xCell2Analysis.R
@@ -188,7 +188,7 @@ xCell2Analysis <- function(mix,
   }
   
   # Rank mix gene expression matrix
-  mixRanked <- singscore::rankGenes(mix[shared_genes, ])
+  mixRanked <- singscore::rankGenes(mix[shared_genes, ], tiesMethod="average")
   
   # Score and predict
   sigsCellTypes <- unique(unlist(lapply(


### PR DESCRIPTION
Hi Almog. Using xCell has been a great experience, and it’s exciting to see xCell2 released and under active development.

This PR changes the ranking step in `xCell2Analysis()` to explicitly call:

```r
mixRanked <- singscore::rankGenes(mix[shared_genes, ], tiesMethod = "average")
```

The goal is to prevent rare but disruptive failures where xCell2 aborts due to **negative raw enrichment values** generated during singScore scoring when the default tie-handling is used.

#### The issue
`xCell2Analysis()` computes per-signature enrichment via:

- `mixRanked <- singscore::rankGenes(...)`
- `singscore::simpleScore(mixRanked, centerScore = FALSE)$TotalScore`

Then it averages signature scores and **stops** if any cell type has a negative score in any sample:

```r
if (length(neg_enrichment) > 0) stop("There is a problem with the following samples: ...")
```

When this happens, users see:

> “There is a problem with the following samples: … Please check your input.”

#### Why negative scores should not be considered an error
With a single `upSet`, singScore computes (per sample) a normalized score from the **mean rank** of the signature genes:

- Mean rank: $\bar{r} = \mathrm{mean}(r_1,\ldots,r_m)$
- Bounds (non-stable ranks): $\mathrm{low} = (m+1)/2$, $\mathrm{up} = (2N-m+1)/2$
- Score: $s = (\bar{r}-\mathrm{low})/(\mathrm{up}-\mathrm{low})$ (and here `centerScore = FALSE`, so no -0.5 offset)

Negatives simply mean $\bar{r} < \mathrm{low}$, which can occur due to **tie handling**, not invalid input. As an extreme example, with the default `tiesMethod = "min"`, a large tied-low block (often many zeros) assigns all genes in that block rank \(1\). If many signature genes fall in that block, $\bar{r}\approx 1$, so:

$$
s \approx \frac{1-(m+1)/2}{\mathrm{up}-\mathrm{low}} < 0
$$

This is most likely in legitimate biological/technical contexts where ties are common:
- low-depth RNA-seq / sparse samples
- degraded RNA / poor library complexity
- numeric round/coarsen (e.g., TPM rounded to integer or few decimals), inflating ties

So the input can be numerically valid; the negative value is a rank/bounds artifact driven by ties when `tiesMethod="min"`.

#### Two ways to fixes
There are two reasonable paths:

1) Fix at the source (this PR): set `tiesMethod="average"` (or `"max"`, both mathematically ensure $\bar{r} < \mathrm{low}$)
2) Change xCell2 behavior around negatives
   Replace the hard `stop()` with a warning that negatives were observed, and document what they mean so that users will decide what to do (e.g., clip to zero, drop affected samples, revisit preprocessing, or keep values for diagnostics).

This PR adopts option (1) because it is the simple: it prevents unexpected analysis failure without requiring manual triage.

#### Caveat
This change means **results from prior versions cannot be reproduced exactly**, because tie handling affects ranks (especially in tie-heavy samples). For most typical RNA-seq inputs, differences should be minimal; the impact is largest precisely in the edge cases where ties are pervasive and the current behavior can fail.
